### PR TITLE
Update links to the new github org

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Participation in this group requires signing the
 do by creating a pull request that adds your name, email address, and Community
 Specification License version that you agree to be bound by.
 
-Here is an [example of what that pull request should look like](https://github.com/lottie-animation-community/docs/pull/2).
+Here is an [example of what that pull request should look like](https://github.com/lottie/lottie-spec/pull/9).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,10 +6,10 @@ theme:
     name: cinder
     custom_dir: tools/theme
     highlightjs: false
-repo_url: https://github.com/lottie-animation-community/lottie-spec
-edit_uri: https://github.com/lottie-animation-community/lottie-spec/edit/main/docs
+repo_url: https://github.com/lottie/lottie-spec
+edit_uri: https://github.com/lottie/lottie-spec/edit/main/docs
 use_directory_urls: true
-site_url: https://lottie-animation-community.github.io/lottie-spec/
+site_url: https://lottie.github.io/lottie-spec/
 markdown_extensions:
     # - md_in_html
     - lottie_markdown

--- a/schema/root.json
+++ b/schema/root.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/lottie-animation-community/lottie-spec/schema/",
+    "$id": "https://lottie.github.io/lottie-spec/specs/schema/",
     "$ref": "#/$defs/composition/animation"
 }


### PR DESCRIPTION
Updates some urls to the new github org.

There is still one left in https://github.com/lottie/lottie-spec/blob/main/2._Scope.md referencing the tests repo. 
I'm not sure what we decided on, are we going to use lottie-spec for rendering examples as well or are we going to use a different repo?