### PR TITLE
Create strict schema version of the spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 docs/lottie.schema.json
+docs/lottie-strict.schema.json
 site/
 __pycache__
+.vscode/launch.json
 
 # Operating system
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SOURCE_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 OUTPUT_DIR ?= $(CURDIR)/site
 
 .SUFFIXES:
-.PHONY: all install_dependencies docs docs_serve lottie.schema.json validate validate_links
+.PHONY: all install_dependencies docs docs_serve lottie.schema.json lottie-strict.schema.json validate validate_links
 
 
 all: docs
@@ -18,6 +18,12 @@ lottie.schema.json:$(SOURCE_DIR)/docs/lottie.schema.json
 $(SOURCE_DIR)/docs/lottie.schema.json: $(wildcard $(SOURCE_DIR)/schema/**/*.json)
 $(SOURCE_DIR)/docs/lottie.schema.json: $(SOURCE_DIR)/tools/schema-merge.py
 	$(SOURCE_DIR)/tools/schema-merge.py
+
+lottie-strict.schema.json:$(SOURCE_DIR)/docs/lottie-strict.schema.json
+
+$(SOURCE_DIR)/docs/lottie-strict.schema.json: $(SOURCE_DIR)/docs/lottie.schema.json
+$(SOURCE_DIR)/docs/lottie-strict.schema.json: $(SOURCE_DIR)/tools/schema-strictify.py
+	$(SOURCE_DIR)/tools/schema-strictify.py
 
 docs:$(OUTPUT_DIR)/index.html
 
@@ -32,9 +38,9 @@ docs_serve:$(SOURCE_DIR)/docs/lottie.schema.json
 install_dependencies:
 	$(PIP) install -r $(SOURCE_DIR)/tools/requirements.txt
 
-validate: $(SOURCE_DIR)/docs/lottie.schema.json
+validate: $(SOURCE_DIR)/docs/lottie.schema.json $(SOURCE_DIR)/docs/lottie-strict.schema.json
 	$(SOURCE_DIR)/tools/schema-validate.py
-
+	$(SOURCE_DIR)/tools/schema-validate.py --schema $(SOURCE_DIR)/docs/lottie-strict.schema.json
 
 validate_full:$(OUTPUT_DIR)/index.html
 	$(SOURCE_DIR)/tools/schema-validate.py --html $(OUTPUT_DIR)/specs

--- a/docs/specs/schema.md
+++ b/docs/specs/schema.md
@@ -9,4 +9,7 @@ values to jump to the relevant section.
 
 If you want you can also view the [raw schema file](../lottie.schema.json).
 
+There is also a [strict schema file](../lottie-strict.schema.json)
+that disallows properties not covered in the specification.
+
 {json_file}

--- a/tools/schema-strictify.py
+++ b/tools/schema-strictify.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import os
+import json
+import pathlib
+import argparse
+
+# Ignored subschemas
+# With how inheritance is acheived in json schema with allOf, we can't have 
+# strict schemas be extended, as the additional fields of the child would cause
+# the parent schema to fail validation.
+ignored_subschemas = [
+    'visual-object',
+    'asset',
+    'composition',
+    'visual-layer',
+    'layer',
+    'vector-keyframe',
+    'base-keyframe',
+    'shape',
+    'graphic-element',
+    'modifier',
+    'transform',
+    'shape-style'
+]
+
+def strictify_fields(
+    json_data: dict,
+):
+    for module, module_data in json_data['$defs'].items():
+        for attr, attr_data in module_data.items():
+            if 'type' in attr_data and attr_data['type'] == 'object' and attr not in ignored_subschemas:
+                attr_data['unevaluatedProperties'] = False
+
+    return json_data
+
+root = pathlib.Path(__file__).absolute().parent.parent
+
+parser = argparse.ArgumentParser(
+    description="Joins JSON schema in a single file")
+parser.add_argument(
+    "--input", "-i",
+    type=pathlib.Path,
+    default=root / "docs" / "lottie.schema.json",
+    help="Input file name"
+)
+
+parser.add_argument(
+    "--output", "-o",
+    type=pathlib.Path,
+    default=root / "docs" / "lottie-strict.schema.json",
+    help="Output file name"
+)
+
+args = parser.parse_args()
+input_path: pathlib.Path = args.input
+output_path: pathlib.Path = args.output
+
+with open(input_path) as file:
+    json_data = json.load(file)
+
+strictify_fields(json_data)
+
+os.makedirs(output_path.parent, exist_ok=True)
+
+with open(output_path, "w") as file:
+    json.dump(json_data, file, indent=4)


### PR DESCRIPTION
First pass at creating a script to create a strict version of the spec by using the generated schema and adding `unevaluatedProperties: false` to subschemas.

With this approach, extended subschemas can't have this property. We will probably need another pass at the schema to ensure extended subschemas aren't used both as extensions and references.

This will be useful for-
1. Clients that want to ensure they aren't using unspecified fields. They made need some sanitization of the lottie from common tools, depending on on the final schema state.
2. Identifying parts of the schema that we have not yet documented.