### PR TITLE
Resolve schema failures with embedded images

### DIFF
--- a/schema/assets/image.json
+++ b/schema/assets/image.json
@@ -23,10 +23,7 @@
                 "p": {
                     "title": "File Name",
                     "description": "Name of the image file or a data url",
-                    "oneOf": [
-                        {"type": "string"},
-                        {"$ref": "#/$defs/values/data-url"}
-                    ]
+                    "type": "string"
                 },
                 "u": {
                     "title": "File Path",
@@ -39,6 +36,20 @@
                     "$ref": "#/$defs/values/int-boolean"
                 }
             },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "e": 1
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "p": {"$ref": "#/$defs/values/data-url"}
+                        }
+                    }
+                }
+            ],
             "required": ["w", "h", "p"]
         }
     ]


### PR DESCRIPTION
Embedded image is also a string, so would result in both oneOf checks passing and thus triggering a failure.

Instead, conditionally check the format of image string if it is set to be a data url.