### PR TITLE
Animated bezier object should be in array

### DIFF
--- a/schema/properties/bezier-keyframe.json
+++ b/schema/properties/bezier-keyframe.json
@@ -14,7 +14,9 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/$defs/values/bezier"
-                    }
+                    },
+                    "minItems": 1,
+                    "maxItems": 1
                 }
             }
         }

--- a/schema/properties/bezier-keyframe.json
+++ b/schema/properties/bezier-keyframe.json
@@ -11,7 +11,10 @@
                 "s": {
                     "title": "Value",
                     "description": "Value at this keyframe.",
-                    "$ref": "#/$defs/values/bezier"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/values/bezier"
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is how bodymovin exports animated paths.

I'm not sure if other tools export with `s` being the object directly. Ideally it would be nice to have a single way to represent these, though maybe there are technical/pragmatic reasons to support both approaches.