### PR TITLE
Slots Schema

### DIFF
--- a/docs/specs/slots.md
+++ b/docs/specs/slots.md
@@ -1,0 +1,27 @@
+# Slots
+
+Slots are used to replace property values during runtime. Properties that can be replaced will have an `sid` attribute that will correspond to the slot key entry. Players that support slots must also expose an API that applications can use to replace values during runtime.
+
+<h3 id="color-slot">Color Slot</h3>
+
+{schema_object:slots/color-slot}
+
+<h3 id="point-slot">Point Slot</h3>
+
+{schema_object:slots/point-slot}
+
+<h3 id="scale-slot">Scale Slot</h3>
+
+{schema_object:slots/scale-slot}
+
+<h3 id="float-slot">Float Slot</h3>
+
+{schema_object:slots/float-slot}
+
+<h3 id="asset-slot">Asset Slot</h3>
+
+{schema_object:slots/asset-slot}
+
+<h3 id="undefined-slot">Undefined Slot</h3>
+
+{schema_object:slots/undefined-slot}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
         - specs/layers.md
         - specs/shapes.md
         - specs/assets.md
+        - specs/slots.md
         - specs/constants.md
         - specs/helpers.md
         #

--- a/schema/assets/image.json
+++ b/schema/assets/image.json
@@ -37,6 +37,11 @@
                     "title": "Embedded",
                     "description": "If '1', 'p' is a Data URL",
                     "$ref": "#/$defs/values/int-boolean"
+                },
+                "sid": {
+                    "title": "Slot Id",
+                    "description": "Identifier for a property that can be replaced at runtime",
+                    "type": "string"
                 }
             },
             "required": ["w", "h", "p"]

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -50,6 +50,14 @@
                     "items": {
                         "$ref": "#/$defs/helpers/marker"
                     }
+                },
+                "slots": {
+                    "title": "Slots",
+                    "description": "Dictionary of slot ids that can be referenced to change properties at run time",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/slots/all-slots"
+                    }
                 }
             },
             "required": ["w", "h", "fr", "op", "ip"]

--- a/schema/properties/color-property.json
+++ b/schema/properties/color-property.json
@@ -39,5 +39,12 @@
                 }
         }
     ],
+    "properties": {
+        "sid": {
+            "title": "Slot Id",
+            "description": "Identifier for a property that can be replaced at runtime",
+            "type": "string"
+        }
+    },
     "required": ["a", "k"]
 }

--- a/schema/properties/scalar-property.json
+++ b/schema/properties/scalar-property.json
@@ -39,5 +39,12 @@
             }
         }
     ],
+    "properties": {
+        "sid": {
+            "title": "Slot Id",
+            "description": "Identifier for a property that can be replaced at runtime",
+            "type": "string"
+        }
+    },
     "required": ["a", "k"]
 }

--- a/schema/properties/vector-property.json
+++ b/schema/properties/vector-property.json
@@ -40,5 +40,12 @@
             }
         }
     ],
+    "properties": {
+        "sid": {
+            "title": "Slot Id",
+            "description": "Identifier for a property that can be replaced at runtime",
+            "type": "string"
+        }
+    },
     "required": ["a", "k"]
 }

--- a/schema/slots/all-slots.json
+++ b/schema/slots/all-slots.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+        {
+            "$ref": "#/$defs/slots/color-slot"
+        },
+        {
+            "$ref": "#/$defs/slots/scale-slot"
+        },
+        {
+            "$ref": "#/$defs/slots/float-slot"
+        },
+        {
+            "$ref": "#/$defs/slots/asset-slot"
+        },
+        {
+            "$ref": "#/$defs/slots/point-slot"
+        },
+        {
+            "$ref": "#/$defs/slots/undefined-slot"
+        }
+    ]
+}

--- a/schema/slots/asset-slot.json
+++ b/schema/slots/asset-slot.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Asset Slot",
+    "description": "Asset Slot",
+    "properties": {
+        "t": {
+            "title": "Slot Type",
+            "const": 50
+        },
+        "p": {
+            "title": "Default Property Value",
+            "description": "The starting value of any properties with the slot id",
+            "$ref": "#/$defs/assets/image"
+        }
+    }
+}

--- a/schema/slots/color-slot.json
+++ b/schema/slots/color-slot.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Color Slot",
+    "description": "Color Slot",
+    "properties": {
+        "t": {
+            "title": "Slot Type",
+            "const": 1
+        },
+        "p": {
+            "title": "Default Property Value",
+            "description": "The starting value of any properties with the slot id",
+            "$ref": "#/$defs/properties/color-property"
+        }
+    }
+}

--- a/schema/slots/float-slot.json
+++ b/schema/slots/float-slot.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Float Slot",
+    "description": "Float Slot",
+    "properties": {
+        "t": {
+            "title": "Slot Type",
+            "const": 4
+        },
+        "p": {
+            "title": "Default Property Value",
+            "description": "The starting value of any properties with the slot id",
+            "$ref": "#/$defs/properties/scalar-property"
+        }
+    }
+}

--- a/schema/slots/point-slot.json
+++ b/schema/slots/point-slot.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Point Slot",
+    "description": "Point Slot",
+    "properties": {
+        "t": {
+            "title": "Slot Type",
+            "const": 2
+        },
+        "p": {
+            "title": "Default Property Value",
+            "description": "The starting value of any properties with the slot id",
+            "$ref": "#/$defs/properties/vector-property"
+        }
+    }
+}

--- a/schema/slots/scale-slot.json
+++ b/schema/slots/scale-slot.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Scale Slot",
+    "description": "Scale Slot",
+    "properties": {
+        "t": {
+            "title": "Slot Type",
+            "const": 3
+        },
+        "p": {
+            "title": "Default Property Value",
+            "description": "The starting value of any properties with the slot id",
+            "$ref": "#/$defs/properties/vector-property"
+        }
+    }
+}

--- a/schema/slots/undefined-slot.json
+++ b/schema/slots/undefined-slot.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Undefined Slot",
+    "description": "A slot for an unknwown property type",
+    "properties": {
+        "t": {
+            "title": "Slot Type",
+            "const": 99
+        },
+        "p": {
+            "title": "Default Property Value",
+            "description": "The starting value of any properties with the slot id"
+        }
+    }
+}


### PR DESCRIPTION
First attempt at creating a slot schema.

This is based on the current slot implementation in bodymovin, lottie-web and skottie.

Slot types are from https://github.com/bodymovin/bodymovin-extension/blob/4f1de8ebfe5beaebc4c7d54fbbdf363ca685478c/bundle/jsx/utils/essentialPropertiesHelper.jsx#L15. I don't think the slot type is used by the players at all and seems like more of a hint for JSON viewing/editing.

Schema could probably be abstracted better, but I think this should be good enough for initial discussion on slot format.