### PR TITLE
Add specification version field

### DIFF
--- a/docs/specs/composition.md
+++ b/docs/specs/composition.md
@@ -1,12 +1,45 @@
 # Composition
 
-
 <h2 id="animation">Animation</h2>
 
 {schema_string:composition/animation/description}
 
 {schema_object:composition/animation}
 
+### Versioning Guidelines
+
+Tools implementing the Lottie specification should consider the following
+guidelines:
+
+* Major version updates may contain breaking changes that are not compatible
+with previous versions of the specification.
+* Minor version updates are typically adding new functionality and should not
+contain breaking changes.
+* Patch version updates are typically making minor changes to already existing
+functionality.
+
+#### Authoring Tools
+
+Authoring tools should specify the latest version of the Lottie Specification.
+They may want to allow the targeted major version to be configurable to
+facilitate playback on a wide range of players. Changing the targeted major
+version may also require changes to the animation for any breaking changes
+between versions.
+
+Authoring tools should always use the latest minor/patch version for the
+targeted major version(s) as these are backwards compatible, even if the
+authoring tool doesn't support any of the newer functionality.
+
+#### Animation Players
+
+Players should determine what major versions they support and also any
+conditional logic to handle brekaing changes across major versions as needed.
+Players should expect to handle animations that specify both newer and older
+versions of the Lottie specification and should issue a warning if:
+
+* The animation specifies a major version that is not supported.
+* The animation specifies a newer minor version.
+* No warning needed if the specified patch version is different.
 
 <h2 id="composition">Composition</h2>
 

--- a/docs/specs/composition.md
+++ b/docs/specs/composition.md
@@ -15,8 +15,8 @@ guidelines:
 with previous versions of the specification.
 * Minor version updates typically add new functionality and SHOULD NOT
 contain breaking changes.
-* Patch version updates typically make minor changes to already existing
-functionality.
+* Patch version updates typically make minor changes or clarifiactions to
+already existing functionality.
 
 #### Authoring Tools
 

--- a/docs/specs/composition.md
+++ b/docs/specs/composition.md
@@ -8,34 +8,34 @@
 
 ### Versioning Guidelines
 
-Tools implementing the Lottie specification should consider the following
+Tools implementing the Lottie specification SHOULD consider the following
 guidelines:
 
-* Major version updates may contain breaking changes that are not compatible
+* Major version updates MAY contain breaking changes that are not compatible
 with previous versions of the specification.
-* Minor version updates are typically adding new functionality and should not
+* Minor version updates are typically adding new functionality and SHOULD NOT
 contain breaking changes.
 * Patch version updates are typically making minor changes to already existing
 functionality.
 
 #### Authoring Tools
 
-Authoring tools should specify the latest version of the Lottie Specification.
-They may want to allow the targeted major version to be configurable to
+Authoring tools SHOULD specify the latest version of the Lottie Specification.
+They MAY want to allow the targeted major version to be configurable to
 facilitate playback on a wide range of players. Changing the targeted major
-version may also require changes to the animation for any breaking changes
+version MAY also require changes to the animation for any breaking changes
 between versions.
 
-Authoring tools should always use the latest minor/patch version for the
+Authoring tools SHOULD always use the latest minor/patch version for the
 targeted major version(s) as these are backwards compatible, even if the
 authoring tool doesn't support any of the newer functionality.
 
 #### Animation Players
 
-Players should determine what major versions they support and also any
+Players SHOULD determine what major versions they support and also any
 conditional logic to handle brekaing changes across major versions as needed.
-Players should expect to handle animations that specify both newer and older
-versions of the Lottie specification and should issue a warning if:
+Players SHOULD expect to handle animations that specify both newer and older
+versions of the Lottie specification and SHOULD issue a warning if:
 
 * The animation specifies a major version that is not supported.
 * The animation specifies a newer minor version.

--- a/docs/specs/composition.md
+++ b/docs/specs/composition.md
@@ -13,29 +13,25 @@ guidelines:
 
 * Major version updates MAY contain breaking changes that are not compatible
 with previous versions of the specification.
-* Minor version updates are typically adding new functionality and SHOULD NOT
+* Minor version updates typically add new functionality and SHOULD NOT
 contain breaking changes.
-* Patch version updates are typically making minor changes to already existing
+* Patch version updates typically make minor changes to already existing
 functionality.
 
 #### Authoring Tools
 
 Authoring tools SHOULD specify the latest version of the Lottie Specification.
-They MAY want to allow the targeted major version to be configurable to
-facilitate playback on a wide range of players. Changing the targeted major
-version MAY also require changes to the animation for any breaking changes
-between versions.
-
-Authoring tools SHOULD always use the latest minor/patch version for the
-targeted major version(s) as these are backwards compatible, even if the
-authoring tool doesn't support any of the newer functionality.
+They MAY allow the major version to be configurable to facilitate playback on a
+wider range of players. Changing the targeted major version MAY also require
+changes to the produced animation in the case of any breaking changes between
+major versions.
 
 #### Animation Players
 
-Players SHOULD determine what major versions they support and also any
-conditional logic to handle brekaing changes across major versions as needed.
-Players SHOULD expect to handle animations that specify both newer and older
-versions of the Lottie specification and SHOULD issue a warning if:
+Players SHOULD determine what major versions they support and handle brekaing
+changes across supported major versions. Players SHOULD expect to handle
+animations that specify both newer and older versions of the Lottie
+specification and SHOULD issue a warning if:
 
 * The animation specifies a major version that is not supported.
 * The animation specifies a newer minor version.

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -14,7 +14,7 @@
                     "title": "Specification Version",
                     "description": "Specification version this Lottie is targeting. This is a 6 digit number with version components encoded as `MMmmpp`, with `MM` being major version, `mm` being minor and `pp` being patch.",
                     "type": "integer",
-                    "minimum": 10000
+                    "minimum": 100
                 },
                 "fr": {
                     "title": "Framerate",

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -12,9 +12,9 @@
             "properties": {
                 "ver": {
                     "title": "Specification Version",
-                    "description": "Specification version this Lottie is targeting",
-                    "type": "string",
-                    "enum": ["1.0"]
+                    "description": "Specification version this Lottie is targeting. This is a 6 digit number with version components encoded as `MMmmpp`, with `MM` being major version, `mm` being minor and `pp` being patch.",
+                    "type": "integer",
+                    "minimum": 10000
                 },
                 "fr": {
                     "title": "Framerate",

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -10,7 +10,7 @@
         {
             "type": "object",
             "properties": {
-                "sv": {
+                "ver": {
                     "title": "Specification Version",
                     "description": "Specification version this Lottie is targeting",
                     "type": "string",

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -10,6 +10,12 @@
         {
             "type": "object",
             "properties": {
+                "sv": {
+                    "title": "Specification Version",
+                    "description": "Specification version this Lottie is targeting",
+                    "type": "string",
+                    "enum": ["1.0"]
+                },
                 "fr": {
                     "title": "Framerate",
                     "description": "Framerate in frames per second",

--- a/schema/root.json
+++ b/schema/root.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://lottie.github.io/lottie-spec/specs/schema/000100",
+    "$id": "https://lottie.github.io/lottie-spec/specs/schema/0.1.0",
     "$ref": "#/$defs/composition/animation",
     "$version": 100
 }

--- a/schema/root.json
+++ b/schema/root.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://lottie.github.io/lottie-spec/specs/schema/",
-    "$ref": "#/$defs/composition/animation"
+    "$id": "https://lottie.github.io/lottie-spec/specs/schema/000100",
+    "$ref": "#/$defs/composition/animation",
+    "$version": 100
 }

--- a/tests/validate_animations.test.js
+++ b/tests/validate_animations.test.js
@@ -8,7 +8,7 @@ const INVALID_ANIMATIONS_DIR = './tests/animations/invalid/';
 const EXAMPLES_DIR = './docs/static/examples/';
 
 const ajv = new Ajv({
-    strict: false
+    keywords:[{keyword:"$version"}]
 });
 const validate = ajv.compile(schema);
 

--- a/tests/validate_animations.test.js
+++ b/tests/validate_animations.test.js
@@ -7,7 +7,9 @@ const VALID_ANIMATIONS_DIR = './tests/animations/valid/';
 const INVALID_ANIMATIONS_DIR = './tests/animations/invalid/';
 const EXAMPLES_DIR = './docs/static/examples/';
 
-const ajv = new Ajv();
+const ajv = new Ajv({
+    strict: false
+});
 const validate = ajv.compile(schema);
 
 describe('run schema validation', () => {

--- a/tools/schema-validate.py
+++ b/tools/schema-validate.py
@@ -73,8 +73,8 @@ class Validator:
     def check_version(self, schema: Schema):
         versionNumber = schema["$version"]
         
-        majorVersion = math.floor(versionNumber / 10000)
-        minorVersion = math.floor((versionNumber % 10000) / 100)
+        majorVersion = versionNumber // 10000
+        minorVersion = (versionNumber % 10000) // 100
         patchVersion = versionNumber % 100
         
         versionString = f'{majorVersion}.{minorVersion}.{patchVersion}'

--- a/tools/schema-validate.py
+++ b/tools/schema-validate.py
@@ -4,7 +4,6 @@ import sys
 import json
 import pathlib
 import argparse
-import math
 
 from schema_tools.schema import SchemaPath, Schema
 import lottie_markdown

--- a/tools/schema-validate.py
+++ b/tools/schema-validate.py
@@ -71,13 +71,13 @@ class Validator:
 
     def check_version(self, schema: Schema):
         versionNumber = schema["$version"]
-        
+
         majorVersion = versionNumber // 10000
         minorVersion = (versionNumber % 10000) // 100
         patchVersion = versionNumber % 100
-        
+
         versionString = f'{majorVersion}.{minorVersion}.{patchVersion}'
-        
+
         if versionString not in schema["$id"]:
             self.error(schema, "Mismatched URI version - expected: %s" % versionString)
 


### PR DESCRIPTION
Since `v` is already in use for bodymovin version, using `sv` here. Open to alternatives. 