### PR TITLE
Clean up inconsistencies in the property schemas

### DIFF
--- a/schema/properties/bezier-property.json
+++ b/schema/properties/bezier-property.json
@@ -14,7 +14,8 @@
                     "const": 0
                 },
                 "k": {
-                    "title": "Static value",
+                    "title": "Value",
+                    "description": "Static Value",
                     "$ref": "#/$defs/values/bezier"
                 }
             }

--- a/schema/properties/color-property.json
+++ b/schema/properties/color-property.json
@@ -19,7 +19,8 @@
                     "const": 0
                 },
                 "k": {
-                    "title": "Static value",
+                    "title": "Value",
+                    "description": "Static Value",
                     "$ref": "#/$defs/values/color"
                 }
             }

--- a/schema/properties/gradient-property.json
+++ b/schema/properties/gradient-property.json
@@ -20,7 +20,8 @@
                             "const": 0
                         },
                         "k": {
-                            "title": "Static value",
+                            "title": "Value",
+                            "description": "Static Value",
                             "$ref": "#/$defs/values/gradient"
                         }
                     }

--- a/schema/properties/position-property.json
+++ b/schema/properties/position-property.json
@@ -3,6 +3,11 @@
     "type": "object",
     "title": "Position Property",
     "description": "An animatable property to represent a position in space",
+    "allOf": [
+        {
+            "$ref": "#/$defs/helpers/slottable-property"
+        }
+    ],
     "oneOf": [
         {
             "$comment": "Not animated",
@@ -14,7 +19,8 @@
                     "const": 0
                 },
                 "k": {
-                    "title": "Static value",
+                    "title": "Value",
+                    "description": "Static Value",
                     "$ref": "#/$defs/values/vector"
                 }
             }

--- a/schema/properties/scalar-property.json
+++ b/schema/properties/scalar-property.json
@@ -19,7 +19,8 @@
                     "const": 0
                 },
                 "k": {
-                    "title": "Static value",
+                    "title": "Value",
+                    "description": "Static Value",
                     "type": "number"
                 }
             }
@@ -43,12 +44,5 @@
                 }
             }
         }
-    ],
-    "properties": {
-        "sid": {
-            "title": "Slot Id",
-            "description": "Identifier for a property that can be replaced at runtime",
-            "type": "string"
-        }
-    }
+    ]
 }


### PR DESCRIPTION
* Aligned all schemas so static `k` now has name/description (same as what vector-property had)
* Made position property slottable
* Removed duplicate "sid" for scalar property