### PR TITLE
Fix some minor things regarding splittable position

### DIFF
--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -123,9 +123,9 @@ Animatable 2D {link:values/vector} with optional spatial tangents.
 {schema_object:properties/position-keyframe}
 
 <div id="split-position"></div>
-<h4 id="splitable-position-property">Split Position</h4>
+<h4 id="splittable-position-property">Split Position</h4>
 
-{schema_string:properties/splitable-position-property/description}
+{schema_string:properties/splittable-position-property/description}
 
 {schema_object:properties/split-position}
 

--- a/schema/helpers/transform.json
+++ b/schema/helpers/transform.json
@@ -14,7 +14,7 @@
                 "p": {
                     "title": "Position",
                     "description": "Position / Translation",
-                    "$ref": "#/$defs/properties/splitable-position-property"
+                    "$ref": "#/$defs/properties/splittable-position-property"
                 },
                 "r": {
                     "title": "Rotation",

--- a/schema/properties/splittable-position-property.json
+++ b/schema/properties/splittable-position-property.json
@@ -1,12 +1,20 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "title": "Splitable Position Property",
+    "title": "Splittable Position Property",
     "description": "An animatable position where position values may be defined and animated separately.",
     "oneOf": [
         {
             "$comment": "Grouped XY position coordinates",
-            "$ref": "#/$defs/properties/position-property"
+            "$ref": "#/$defs/properties/position-property",
+            "properties": {
+                "s": {
+                    "title": "Split",
+                    "description": "Whether the position has split values",
+                    "type": "boolean",
+                    "const": false
+                }
+            }
         },
         {
             "$comment": "Split XY position coordinates",


### PR DESCRIPTION
Adds `s` on the non-split branch of the splittable position (but not required).
This should not change validation but it will make `s` a recognized property in that case (so the validator will not warn if present)

It also renames splitable -> splittable as the latter seems to be a more common spelling.