### PR TITLE
Disallow negative values on some top-level properties

### DIFF
--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -19,7 +19,8 @@
                 "fr": {
                     "title": "Framerate",
                     "description": "Framerate in frames per second",
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0
                 },
                 "ip": {
                     "title": "In Point",
@@ -34,12 +35,14 @@
                 "w": {
                     "title": "Width",
                     "description": "Width of the animation",
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "h": {
                     "title": "Height",
                     "description": "Height of the animation",
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "assets": {
                     "title": "Assets",

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -20,7 +20,7 @@
                     "title": "Framerate",
                     "description": "Framerate in frames per second",
                     "type": "number",
-                    "minimum": 0
+                    "exclusiveMinimum": 0
                 },
                 "ip": {
                     "title": "In Point",


### PR DESCRIPTION
Ensures width/height/framerate are non negative.

Perhaps `fr` should be strictly positive but I didn't want to enforce a minimum framerate (having a framerate of something like 0.5 would be unusual but it still makes sense)