### PR TITLE
Clean up asset schema

### DIFF
--- a/schema/assets/asset.json
+++ b/schema/assets/asset.json
@@ -4,17 +4,14 @@
     "title": "Asset",
     "allOf": [
         {
+            "$ref": "#/$defs/helpers/visual-object"
+        },
+        {
             "type": "object",
             "properties": {
                 "id": {
                     "title": "ID",
                     "description": "Unique identifier used by layers when referencing this asset",
-                    "type": "string",
-                    "default": ""
-                },
-                "nm": {
-                    "title": "Name",
-                    "description": "Human readable name",
                     "type": "string"
                 }
             },

--- a/schema/helpers/visual-object.json
+++ b/schema/helpers/visual-object.json
@@ -9,7 +9,7 @@
             "properties": {
                 "nm": {
                     "title": "Name",
-                    "description": "Name, as seen from editors and the like",
+                    "description": "Human readable name, as seen from editors and the like",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
References visual-object instead of redefining `nm` and removes the default of `id` since `id` is required anyway