### PR TITLE
Fix link to RFC 2397

### DIFF
--- a/docs/specs/values.md
+++ b/docs/specs/values.md
@@ -104,4 +104,4 @@ It's the same array as the case without transparency but with the following valu
 
 <h2 id="data-url">Data URL</h2>
 
-Data URLs are embedded files (such as images) as defined in [RFC2397](https://datatracker.ietf.org/doc/html/rfc2397).
+Data URLs are embedded files (such as images) as defined in [RFC2397].


### PR DESCRIPTION
Small fix, the custom extension was breaking the markdown-style link so just use the short form.