### PR TITLE
Clarify wording on specs versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ An RFC in the Explainer stage captures a described problem or partially-consider
 An explainer does not need to meet any entrance criteria. An Explainer may be an issue or a pull request (though an illustrative pull request is preferable).
 
 #### Entrance criteria
+
 * A well defined problem or use case. 
 * Identification of potential concerns, challenges, and drawbacks.
 

--- a/docs/specs/composition.md
+++ b/docs/specs/composition.md
@@ -8,13 +8,14 @@
 
 ### Versioning Guidelines
 
-Tools implementing the Lottie specification SHOULD consider the following
+The Lottie specification version number uses a semantic versioning system,
+tools implementing the specification SHOULD consider the following
 guidelines:
 
-* Major version updates MAY contain breaking changes that are not compatible
+* Major version signal the possibiliry of breaking changes that are not compatible
 with previous versions of the specification.
-* Minor version updates typically add new functionality and SHOULD NOT
-contain breaking changes.
+* Minor version updates typically add new functionality but do not
+contain breaking changes for existing features.
 * Patch version updates typically make minor changes or clarifiactions to
 already existing functionality.
 
@@ -29,7 +30,7 @@ major versions.
 #### Animation Players
 
 Players SHOULD determine what major versions they support and handle brekaing
-changes across supported major versions. Players SHOULD expect to handle
+changes across supported major versions. Players SHOULD be able to handle
 animations that specify both newer and older versions of the Lottie
 specification and SHOULD issue a warning if:
 

--- a/docs/specs/composition.md
+++ b/docs/specs/composition.md
@@ -12,11 +12,11 @@ The Lottie specification version number uses a semantic versioning system,
 tools implementing the specification SHOULD consider the following
 guidelines:
 
-* Major version signal the possibiliry of breaking changes that are not compatible
+* Major version signal the possibility of breaking changes that are not compatible
 with previous versions of the specification.
 * Minor version updates typically add new functionality but do not
 contain breaking changes for existing features.
-* Patch version updates typically make minor changes or clarifiactions to
+* Patch version updates typically make minor changes or clarifications to
 already existing functionality.
 
 #### Authoring Tools
@@ -29,7 +29,7 @@ major versions.
 
 #### Animation Players
 
-Players SHOULD determine what major versions they support and handle brekaing
+Players SHOULD determine what major versions they support and handle breaking
 changes across supported major versions. Players SHOULD be able to handle
 animations that specify both newer and older versions of the Lottie
 specification and SHOULD issue a warning if:


### PR DESCRIPTION
Making sure it's clear that the versioning guideline applies to the specs itself rather than mandating a versioning system for Lottie-related tools