### PR TITLE
Manually show a and k on property docs

### DIFF
--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -90,6 +90,12 @@ In the following example, the ball moves left and right, on the background you c
 Animatable {link:values/vector}.
 
 {schema_object:properties/vector-property}
+<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k`</td>
+<td>{link:values/vector} or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 
 <h4 id="vector-keyframe">Vector Keyframe</h4>
@@ -107,6 +113,12 @@ Note that when animated it uses {link:properties/vector-keyframe:Vector Keyframe
 so instead of scalars keyframes have arrays with a single values.
 
 {schema_object:properties/scalar-property}
+<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k`</td>
+<td>`number` or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 
 <h3 id="position-property">Position</h3>
@@ -114,6 +126,12 @@ so instead of scalars keyframes have arrays with a single values.
 Animatable 2D {link:values/vector} with optional spatial tangents.
 
 {schema_object:properties/position-property}
+<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k`</td>
+<td>{link:values/vector} or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 
 <h4 id="position-keyframe">Position Keyframe</h4>
@@ -134,6 +152,12 @@ Animatable 2D {link:values/vector} with optional spatial tangents.
 Animatable {link:values/bezier}.
 
 {schema_object:properties/bezier-property}
+<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k`</td>
+<td>{link:values/bezier} or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 
 <h4 id="bezier-keyframe">Bezier Shape Keyframe</h4>
@@ -147,6 +171,12 @@ Animatable {link:values/bezier}.
 Animatable {link:values/color}.
 
 {schema_object:properties/color-property}
+<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k`</td>
+<td>{link:values/color} or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 
 <h4 id="color-keyframe">Color Keyframe</h4>
@@ -160,6 +190,12 @@ Animatable {link:values/color}.
 Animatable {link:values/gradient}.
 
 {schema_object:properties/gradient-property}
+<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k`</td>
+<td>{link:values/gradient} or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 Color count is not animatable.
 

--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -190,6 +190,12 @@ Animatable {link:values/color}.
 Animatable {link:values/gradient}.
 
 {schema_object:properties/gradient-property}
+<tr><td>`k.a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
+<tr><td>`k.k`</td>
+<td>{link:values/gradient} or `array`</td>
+<td>Value or Keyframes</td>
+<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
+</tr>
 
 Color count is not animatable.
 

--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -190,12 +190,6 @@ Animatable {link:values/color}.
 Animatable {link:values/gradient}.
 
 {schema_object:properties/gradient-property}
-<tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
-<tr><td>`k`</td>
-<td>{link:values/gradient} or `array`</td>
-<td>Value or Keyframes</td>
-<td>When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes.</td>
-</tr>
 
 Color count is not animatable.
 

--- a/schema/properties/gradient-property.json
+++ b/schema/properties/gradient-property.json
@@ -7,44 +7,11 @@
         "p": {
             "title": "Color stop count",
             "type": "number"
-        }
-    },
-    "oneOf": [
-        {
-            "$comment": "Not animated",
-            "properties": {
-                "a": {
-                    "title": "Animated",
-                    "description": "Whether the property is animated",
-                    "$ref": "#/$defs/values/int-boolean",
-                    "const": 0
-                },
-                "k": {
-                    "title": "Value",
-                    "description": "Static Value",
-                    "$ref": "#/$defs/values/gradient"
-                }
-            }
         },
-        {
-            "$comment": "Animated",
-            "properties": {
-                "a": {
-                    "title": "Animated",
-                    "description": "Whether the property is animated",
-                    "$ref": "#/$defs/values/int-boolean",
-                    "const": 1
-                },
-                "k": {
-                    "type": "array",
-                    "title": "Keyframes",
-                    "description": "Array of keyframes",
-                    "items": {
-                            "$ref": "#/$defs/properties/gradient-keyframe"
-                        }
-                    }
-                }
+        "k": {
+            "title": "Gradient stops",
+            "description": "Animatable vector representing the gradient stops",
+            "$ref": "#/$defs/properties/vector-property"
         }
-    ],
-    "required": ["a", "k"]
+    }
 }

--- a/schema/properties/gradient-property.json
+++ b/schema/properties/gradient-property.json
@@ -7,46 +7,44 @@
         "p": {
             "title": "Color stop count",
             "type": "number"
+        }
+    },
+    "oneOf": [
+        {
+            "$comment": "Not animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/values/int-boolean",
+                    "const": 0
+                },
+                "k": {
+                    "title": "Value",
+                    "description": "Static Value",
+                    "$ref": "#/$defs/values/gradient"
+                }
+            }
         },
-        "k": {
-            "oneOf": [
-                {
-                    "$comment": "Not animated",
-                    "properties": {
-                        "a": {
-                            "title": "Animated",
-                            "description": "Whether the property is animated",
-                            "$ref": "#/$defs/values/int-boolean",
-                            "const": 0
-                        },
-                        "k": {
-                            "title": "Value",
-                            "description": "Static Value",
-                            "$ref": "#/$defs/values/gradient"
+        {
+            "$comment": "Animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/values/int-boolean",
+                    "const": 1
+                },
+                "k": {
+                    "type": "array",
+                    "title": "Keyframes",
+                    "description": "Array of keyframes",
+                    "items": {
+                            "$ref": "#/$defs/properties/gradient-keyframe"
                         }
                     }
-                },
-                {
-                    "$comment": "Animated",
-                    "properties": {
-                        "a": {
-                            "title": "Animated",
-                            "description": "Whether the property is animated",
-                            "$ref": "#/$defs/values/int-boolean",
-                            "const": 1
-                        },
-                        "k": {
-                            "type": "array",
-                            "title": "Keyframes",
-                            "description": "Array of keyframes",
-                            "items": {
-                                    "$ref": "#/$defs/properties/gradient-keyframe"
-                                }
-                            }
-                        }
                 }
-            ],
-            "required": ["a", "k"]
         }
-    }
+    ],
+    "required": ["a", "k"]
 }

--- a/schema/properties/gradient-property.json
+++ b/schema/properties/gradient-property.json
@@ -9,9 +9,47 @@
             "type": "number"
         },
         "k": {
+            "type": "object",
             "title": "Gradient stops",
             "description": "Animatable vector representing the gradient stops",
-            "$ref": "#/$defs/properties/vector-property"
+            "oneOf": [
+                {
+                    "$comment": "Not animated",
+                    "properties": {
+                        "a": {
+                            "title": "Animated",
+                            "description": "Whether the property is animated",
+                            "$ref": "#/$defs/values/int-boolean",
+                            "const": 0
+                        },
+                        "k": {
+                            "title": "Value",
+                            "description": "Static Value",
+                            "$ref": "#/$defs/values/gradient"
+                        }
+                    }
+                },
+                {
+                    "$comment": "Animated",
+                    "properties": {
+                        "a": {
+                            "title": "Animated",
+                            "description": "Whether the property is animated",
+                            "$ref": "#/$defs/values/int-boolean",
+                            "const": 1
+                        },
+                        "k": {
+                            "type": "array",
+                            "title": "Keyframes",
+                            "description": "Array of keyframes",
+                            "items": {
+                                    "$ref": "#/$defs/properties/gradient-keyframe"
+                                }
+                            }
+                        }
+                }
+            ],
+            "required": ["a", "k"]
         }
     }
 }

--- a/tools/lottie_markdown.py
+++ b/tools/lottie_markdown.py
@@ -313,6 +313,9 @@ class SchemaObject(BlockProcessor):
             graph = inheritance.inheritance_graph(type)
             details.append(graph)
 
+        if not has_own_props and blocks and (block_to_html(self, blocks[0]) or "").startswith("<tr"):
+            has_own_props = True
+
         if has_own_props:
             table = etree.SubElement(div, "table")
             thead = etree.SubElement(etree.SubElement(table, "thead"), "tr")
@@ -327,6 +330,20 @@ class SchemaObject(BlockProcessor):
 
             for name, prop in prop_dict.items():
                 self.prop_row(name, prop, tbody)
+
+            # Append any trailing <tr> to the table
+            last_tr = -1
+            for i, block in enumerate(blocks):
+                if block == "":
+                    continue
+                next_html = block_to_html(self, block)
+                if not next_html or not next_html.startswith("<tr"):
+                    break
+                last_tr = i
+                tbody.append(etree_fromstring(next_html))
+
+            for i in range(last_tr + 1):
+                blocks.pop(0)
 
         return True
 
@@ -981,6 +998,14 @@ class LottieColor(InlineProcessor):
             code.text = "[%s]" % ", ".join("%.3g" % x for x in comp)
 
         return span, match.start(0), match.end(0)
+
+
+def block_to_html(block_processor, block):
+    match = HTML_PLACEHOLDER_RE.match(block)
+    if match:
+        index = int(match.group(1))
+        return block_processor.parser.md.htmlStash.rawHtmlBlocks[index]
+    return None
 
 
 def pop_script_block(block_processor, blocks):

--- a/tools/schema_tools/type_info.py
+++ b/tools/schema_tools/type_info.py
@@ -52,6 +52,9 @@ class Property(Type):
 
     def resolve_type(self, schema: Schema):
         if "oneOf" in schema:
+            local_type = schema.get("type", None)
+            if local_type is not None:
+                return local_type
             return [self.resolve_type(choice) for choice in schema / "oneOf"]
         if "$ref" in schema:
             return self.type_system.types[schema["$ref"]]


### PR DESCRIPTION
Solves #35 

This does a couple things:
* Expands the `schema_object` block processor to include custom `<tr` elements into the table
* Adds title/description to gradient property `k`
* Adds relevant `k` and `a` rows on the property docs page