### PR TITLE
Rename print_page to single-page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,6 @@ To understand Lottie data, it's useful to start learning about
 
 The root object of any Lottie animation is the [Animation](./specs/composition.md#animation) object.
 
-A printable single-page version of the specification is available [here](./print_page).
+A printable single-page version of the specification is available [here](./single-page).
 
 <lottie src="static/logo.json" loop="false" buttons="false" background="none" />

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
     - print-site:
         add_table_of_contents: false
         enumerate_headings_depth: 3
+        print_page_basename: single-page
         exclude:
           - editing/schema.md
           - editing/extensions.md

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,7 +1,7 @@
 mkdocs==1.5.3
 mkdocs-cinder==1.2.0
 # mkdocs-print-site-plugin==2.5.0
-git+https://github.com/mbasaglia/mkdocs-print-site-plugin.git@clean-toc
+git+https://github.com/mbasaglia/mkdocs-print-site-plugin.git@rename-page
 graphviz==0.20.1
 latex2mathml==3.77.0
 # Used for link validations


### PR DESCRIPTION
I just think it looks better, created an [upstream PR](https://github.com/timvink/mkdocs-print-site-plugin/pull/118) to add this options. Setting this to draft to see if they merge it.