### PR TITLE
Schema 1.0

### DIFF
--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -14,7 +14,7 @@
                     "title": "Specification Version",
                     "description": "Specification version this Lottie is targeting. This is a 6 digit number with version components encoded as `MMmmpp`, with `MM` being major version, `mm` being minor and `pp` being patch.",
                     "type": "integer",
-                    "minimum": 100
+                    "minimum": 10000
                 },
                 "fr": {
                     "title": "Framerate",

--- a/schema/root.json
+++ b/schema/root.json
@@ -2,5 +2,5 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://lottie.github.io/lottie-spec/1.0/specs/schema/",
     "$ref": "#/$defs/composition/animation",
-    "$version": 1000000
+    "$version": 10000
 }

--- a/schema/root.json
+++ b/schema/root.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://lottie.github.io/lottie-spec/specs/schema/0.1.0",
+    "$id": "https://lottie.github.io/lottie-spec/1.0/specs/schema/",
     "$ref": "#/$defs/composition/animation",
-    "$version": 100
+    "$version": 1000000
 }

--- a/tools/schema-validate.py
+++ b/tools/schema-validate.py
@@ -70,16 +70,20 @@ class Validator:
                 self.collect_defs(child)
 
     def check_version(self, schema: Schema):
-        versionNumber = schema["$version"]
+        version_number = schema["$version"]
 
-        majorVersion = versionNumber // 10000
-        minorVersion = (versionNumber % 10000) // 100
-        patchVersion = versionNumber % 100
+        major_version = version_number // 10000
+        minor_version = (version_number % 10000) // 100
+        patch_version = version_number % 100
 
-        versionString = f'{majorVersion}.{minorVersion}.{patchVersion}'
+        components = [major_version, minor_version]
+        if patch_version != 0:
+            components.append(patch_version)
 
-        if versionString not in schema["$id"]:
-            self.error(schema, "Mismatched URI version - expected: %s" % versionString)
+        version_string = ".".join(map(str, components))
+
+        if version_string not in schema["$id"]:
+            self.error(schema, "Mismatched URI version - expected: %s" % version_string)
 
     def check_links(self, html_path: pathlib.Path):
         checked = set()


### PR DESCRIPTION
Drafting this to be merged before release.

`$id` will point to the HTML page showing the interactive schema, so people using the schema can easily find the docs.

Draft because we should merge this as one of the last steps before release, however if we package the JSON schema, we should do that with these changes included.