### PR TITLE
Small schema fixes

### DIFF
--- a/schema/layers/layer.json
+++ b/schema/layers/layer.json
@@ -41,7 +41,7 @@
                     "type": "number"
                 }
             },
-            "required": ["ty", "st", "ip", "op"]
+            "required": ["ty", "ip", "op"]
         }
     ]
 }

--- a/schema/shapes/base-gradient.json
+++ b/schema/shapes/base-gradient.json
@@ -30,16 +30,12 @@
                 "h": {
                     "title": "Highlight Length",
                     "description": "Highlight Length, as a percentage between `s` and `e`",
-                    "$ref": "#/$defs/properties/scalar-property",
-                    "minimum": 0,
-                    "maximum": 1
+                    "$ref": "#/$defs/properties/scalar-property"
                 },
                 "a": {
                     "title": "Highlight Angle",
                     "description": "Highlight Angle in clockwise degrees, relative to the direction from `s` to `e`",
-                    "$ref": "#/$defs/properties/scalar-property",
-                    "minimum": 0,
-                    "maximum": 360
+                    "$ref": "#/$defs/properties/scalar-property"
                 }
             },
             "required": [


### PR DESCRIPTION
1. Remove `st` as required field on layer. This field was removed in https://github.com/lottie/lottie-spec/pull/53
2. Remove min/max on some gradient scalar properties. Scalar properties are objects and the values are in `k`, so min/max doesn't apply at that level. We would need to reach deeper into the object to properly apply limits.

These were discovered using full strict mode on ajv. We may want to turn this on in our tests, however I was having some issues with cases where the property definition and required were split between if/then/allof etc.