### PR TITLE
Handle stroke dash array edge cases.

### DIFF
--- a/docs/specs/shapes.md
+++ b/docs/specs/shapes.md
@@ -477,6 +477,8 @@ A stroke dash array consists of `n` dash entries, `[n-1,n]` gap entries and `[0-
 
 Dash and gap entries MUST all be in a continuous order and alternate between dash and gap, starting with dash. If there are an odd number of dashes + gaps, the sequence will repeat with dashes and gaps reversed. For example a sequence of `[4d, 8g, 16d]` MUST be rendered as `[4d, 8g, 16d, 4g, 8d, 16g]`.
 
+If any of the dash or gap entries are less than 0, or if the total sum of all their values is 0, the whole dash array is ignored, and the stroke MUST be treated as if the dash was not set.
+
 Offset entry, if present, MUST be at the end of the array.
 
 {schema_object:shapes/stroke-dash}


### PR DESCRIPTION
The expected behavior has been clarified for the case of setting negative values for dash/gap entries, as well as when the sum of all their values is zero.
The behavior is consistent now with the one defined by the SVG standard.

Note:
the results from lottie-web and AE are consistent with this change (in AE only the total sum was tested, it is not possible to set values < 0)

lottie-web 
<img width="154" alt="Zrzut ekranu 2025-02-17 o 14 20 14" src="https://github.com/user-attachments/assets/4f1e0654-769f-4ddd-8ee1-a8fdab7ecb0e" />

sample: 
[dash_zeros.json](https://github.com/user-attachments/files/18825871/dash_zeros.json)

tested cases:
`0`
`20 0`
`0 20`
`20 0 20`
`0 20 0`
`20 20 -1`
`0 0`