### PR TITLE
Bump schema version for 1.0.1

### DIFF
--- a/schema/root.json
+++ b/schema/root.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://lottie.github.io/lottie-spec/1.0/specs/schema/",
+    "$id": "https://lottie.github.io/lottie-spec/1.0.1/specs/schema/",
     "$ref": "#/$defs/composition/animation",
     "$version": 10001
 }

--- a/schema/root.json
+++ b/schema/root.json
@@ -2,5 +2,5 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://lottie.github.io/lottie-spec/1.0/specs/schema/",
     "$ref": "#/$defs/composition/animation",
-    "$version": 10000
+    "$version": 10001
 }


### PR DESCRIPTION
We'll need to update the 1.0.1 tag once this is merged