### PR TITLE
feat: Extend Lottie specification with VideoFrame asset support

### DIFF
--- a/docs/specs/assets.md
+++ b/docs/specs/assets.md
@@ -30,3 +30,25 @@ Even if an image asset does not have any intrinsic size, its contents MUST
 still stay within the `w`-`h` bounds when rendered.
 
 Authoring tools SHOULD export files where `w` and `h` match the physical size of the assets.
+
+<h2 id="video">Video</h2>
+
+{schema_string:assets/video/description}
+
+Video formats supported vary depending on the player. Some commonly supported formats are MP4, WebM, and MOV.
+
+{schema_object:assets/video}
+
+Video assets define the source video content that can be referenced by video frame assets.
+This enables the use of video compression techniques to reduce the overall animation size, when working with raster-based animations.
+
+Players MUST support extracting individual frames from video assets at specified timestamps when initializing animations.
+
+<h2 id="video-frame">Video Frame</h2>
+
+{schema_string:assets/video-frame/description}
+
+{schema_object:assets/video-frame}
+
+Video frame assets reference a video asset by ID and specify a timestamp to extract a specific frame. Players MUST extract the frame at the exact timestamp specified, or the closest available frame if the exact timestamp is not available. The extracted frame should be treated as a static image for rendering purposes.
+

--- a/schema/assets/all-assets.json
+++ b/schema/assets/all-assets.json
@@ -6,6 +6,12 @@
         },
         {
             "$ref": "#/$defs/assets/image"
+        },
+        {
+            "$ref": "#/$defs/assets/video"
+        },
+        {
+            "$ref": "#/$defs/assets/video-frame"
         }
     ]
 }

--- a/schema/assets/video-frame.json
+++ b/schema/assets/video-frame.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Video Frame",
+    "description": "Asset representing a frame from a video at a specific timestamp.",
+    "allOf": [
+        {
+            "$ref": "#/$defs/assets/asset"
+        },
+        {
+            "$ref": "#/$defs/helpers/slottable-object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "vsid": {
+                    "title": "Video Asset ID",
+                    "description": "ID of the video asset to extract frame from",
+                    "type": "string"
+                },
+                "t": {
+                    "title": "Timestamp",
+                    "description": "Timestamp in seconds where to extract the frame from the video",
+                    "type": "number",
+                    "minimum": 0
+                },
+                "w": {
+                    "title": "Width",
+                    "description": "Width of the frame",
+                    "type": "number"
+                },
+                "h": {
+                    "title": "Height",
+                    "description": "Height of the frame",
+                    "type": "number"
+                }
+            },
+            "if": {
+                "required": ["sid"]
+            },
+            "else": {
+                "required": ["vsid", "t"]
+            }
+        }
+    ]
+}

--- a/schema/assets/video.json
+++ b/schema/assets/video.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Video",
+    "description": "Asset containing a video that can be referenced by layers or video frame assets.",
+    "allOf": [
+        {
+            "$ref": "#/$defs/assets/asset"
+        },
+        {
+            "$ref": "#/$defs/helpers/slottable-object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "w": {
+                    "title": "Width",
+                    "description": "Width of the video",
+                    "type": "number"
+                },
+                "h": {
+                    "title": "Height",
+                    "description": "Height of the video",
+                    "type": "number"
+                },
+                "duration": {
+                    "title": "Duration",
+                    "description": "Duration of the video in seconds",
+                    "type": "number",
+                    "minimum": 0
+                },
+                "p": {
+                    "title": "File Name",
+                    "description": "Name of the video file or a data url",
+                    "type": "string"
+                },
+                "u": {
+                    "title": "File Path",
+                    "description": "Path to the video file",
+                    "type": "string"
+                },
+                "e": {
+                    "title": "Embedded",
+                    "description": "If '1', 'p' is a Data URL",
+                    "$ref": "#/$defs/values/int-boolean"
+                }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "e": {"const": 1}
+                        },
+                        "required": ["e"]
+                    },
+                    "then": {
+                        "properties": {
+                            "p": {"$ref": "#/$defs/values/data-url"}
+                        }
+                    }
+                }
+            ],
+            "if": {
+                "required": ["sid"]
+            },
+            "else": {
+                "required": ["w", "h", "duration", "p"]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Title: 

Motivation

Currently, raster animations in Lottie are supported as sequences of frames where images are embedded directly. Since no interframe coding happens under the hood, raster animations are very large. Lottie is not just a vector format, it is also used as a universal animation format. Adding support for frames extracted from video resources makes animation size much smaller. Modern systems support a variety of codecs, so video processing and frame extraction will not be a problem.

Changes:
Add VideoAsset with id, resourceUrl, duration, width, height.
Add VideoFrame asset, similar to ImageAsset, but referencing a VideoAsset by id and specifying a timestamp.


This is a painless schema change. Players can keep their existing image-sequence engines: when encountering VideoFrame, simply extract the frame from the video, convert it to a base64 PNG, and treat it as a normal ImageAsset.

Effectively:

lottieWithVideoFrames -> lottieWithImageSequence
