### PR TITLE
Add slot validation rules and type constraints to specification

### DIFF
--- a/docs/specs/helpers.md
+++ b/docs/specs/helpers.md
@@ -187,7 +187,7 @@ replacement.
 **Type Consistency Rule:**
 
 - The type of a Slot's `p` property MUST match the type of the property that references it via `sid`
-- Vector-type slots MAY target Position properties (and vice versa) if the number of dimensions match, as implementations perform simple value substitution
+- Vector-type slots MAY target Position properties if the number of dimensions match, as implementations perform simple value substitution
 
 **Duplicate Slot ID Rule:**
 

--- a/docs/specs/helpers.md
+++ b/docs/specs/helpers.md
@@ -182,6 +182,30 @@ replacement.
 
 {schema_object:helpers/slottable-property}
 
+<h3 id="slot-validation-rules">Slot Validation Rules</h3>
+
+**Type Consistency Rule:**
+
+- The type of a Slot's `p` property MUST match the type of the property that references it via `sid`
+- Vector-type slots MAY target Position properties (and vice versa) if the number of dimensions match, as implementations perform simple value substitution
+
+**Duplicate Slot ID Rule:**
+
+- Multiple properties MAY reference the same `sid` value
+- All properties referencing the same `sid` MUST have compatible types
+- If multiple `sid` values with identical names but incompatible types exist, implementations SHOULD treat this as an error
+
+**Missing Reference Handling:**
+
+- If a property's `sid` references a slot that does not exist in the `slots` dictionary, implementations MUST use the property's own `a` and `k` values as fallback
+- If a property has only `sid` (no `a`/`k` fallback) and the referenced slot is missing, implementations SHOULD ignore the property or use a type-appropriate default value
+- Slots defined in the `slots` dictionary that are not referenced by any property MAY be ignored
+
+**Type Determination:**
+
+- The type of a slot is determined by the properties that reference it
+- When parsing, implementations SHOULD use the first property referencing a slot to establish its expected type
+
 <lottie-playground example="slots.json">
     <form>
         <input title="Scale X" type="range" min="0" value="100" max="200"/>

--- a/docs/specs/helpers.md
+++ b/docs/specs/helpers.md
@@ -207,6 +207,45 @@ replacement.
 - When parsing, implementations SHOULD check that properties referencing a slot via `sid` are type-compatible with the slot's `p` value
 - If a type mismatch is detected, implementations SHOULD treat this as an error
 
+Valid example — scalar slot referenced by a scalar property:
+
+```json
+{
+    "slots": {
+        "my_rotation": { "p": { "a": 0, "k": 45 } }
+    }
+}
+```
+```json
+{ "a": 0, "k": 0, "sid": "my_rotation" }
+```
+
+Valid example — vector slot referenced by a position property (dimensions match):
+
+```json
+{
+    "slots": {
+        "my_position": { "p": { "a": 0, "k": [100, 200] } }
+    }
+}
+```
+```json
+{ "a": 0, "k": [0, 0], "sid": "my_position" }
+```
+
+Invalid example — scalar slot referenced by a vector property (type mismatch):
+
+```json
+{
+    "slots": {
+        "my_scale": { "p": { "a": 0, "k": 50 } }
+    }
+}
+```
+```json
+{ "a": 0, "k": [100, 100], "sid": "my_scale" }
+```
+
 <lottie-playground example="slots.json">
     <form>
         <input title="Scale X" type="range" min="0" value="100" max="200"/>

--- a/docs/specs/helpers.md
+++ b/docs/specs/helpers.md
@@ -203,8 +203,9 @@ replacement.
 
 **Type Determination:**
 
-- The type of a slot is determined by the properties that reference it
-- When parsing, implementations SHOULD use the first property referencing a slot to establish its expected type
+- The expected type of a slot is determined by its `p` value
+- When parsing, implementations SHOULD check that properties referencing a slot via `sid` are type-compatible with the slot's `p` value
+- If a type mismatch is detected, implementations SHOULD treat this as an error
 
 <lottie-playground example="slots.json">
     <form>

--- a/schema/helpers/slot.json
+++ b/schema/helpers/slot.json
@@ -2,11 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "title": "Slot",
-    "description": "Defines a property value that will be set to all matched properties",
+    "description": "Defines a property value that will be set to all matched properties. The type of `p` must match the type of the properties referencing this slot via `sid`.",
     "properties": {
         "p": {
             "title": "Property Value",
-            "description": "Property Value"
+            "description": "The value to substitute into all properties with a matching `sid`. Must be type-compatible with the target properties."
         }
     },
     "required": ["p"]

--- a/schema/helpers/slottable-object.json
+++ b/schema/helpers/slottable-object.json
@@ -2,11 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "title": "Slottable Object",
-    "description": "Object that may have its value replaced with a slot value",
+    "description": "Object that may have its value replaced with a slot value. When `sid` is present, the object's value is determined by the corresponding slot in the animation's `slots` dictionary.",
     "properties": {
         "sid": {
             "title": "Slot Id",
-            "description": "Identifier to look up the slot",
+            "description": "Identifier that references a slot in the animation's `slots` dictionary. The slot's type must match this property's expected type.",
             "type": "string"
         }
     }

--- a/schema/helpers/slottable-property.json
+++ b/schema/helpers/slottable-property.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "title": "Slottable Property",
-    "description": "Property that may have its value replaced with a slot value",
+    "description": "Property that may have its value replaced with a slot value. When `sid` is present, `a` and `k` are optional fallback values used if the referenced slot is missing.",
     "allOf": [
         {
             "$ref": "#/$defs/helpers/slottable-object"


### PR DESCRIPTION
- related: https://github.com/lottie/lottie-spec/discussions/158

## Summary
  - Add validation rules section to slots documentation covering type consistency, duplicate
  IDs, and missing references
  - Update schema descriptions for `slot`, `slottable-object`, and `slottable-property` with
  type constraint guidance

## Todo

- [x] add examples