### PR TITLE
feat(schema): add ty property type identifier to animatable properties

### DIFF
--- a/docs/specs/constants.md
+++ b/docs/specs/constants.md
@@ -184,6 +184,12 @@ $$Y = 0.2126 R + 0.7152 G + 0.0722 B$$
 
 {schema_enum:gradient-type}
 
+<h2 id="property-type">Property Type</h2>
+
+{schema_string:constants/property-type/description}
+
+{schema_enum:property-type}
+
 <lottie-playground example="gradient.json">
     <title>Example</title>
     <form>

--- a/docs/specs/constants.md
+++ b/docs/specs/constants.md
@@ -184,12 +184,6 @@ $$Y = 0.2126 R + 0.7152 G + 0.0722 B$$
 
 {schema_enum:gradient-type}
 
-<h2 id="property-type">Property Type</h2>
-
-{schema_string:constants/property-type/description}
-
-{schema_enum:property-type}
-
 <lottie-playground example="gradient.json">
     <title>Example</title>
     <form>
@@ -201,3 +195,11 @@ $$Y = 0.2126 R + 0.7152 G + 0.0722 B$$
     gradient.t = Number(data["Type"]);
     </script>
 </lottie-playground>
+
+<h2 id="property-type">Property Type</h2>
+
+{schema_string:constants/property-type/description}
+
+{schema_enum:property-type}
+
+For examples of each property type, see the [Property types](properties.md#vector-property) section.

--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -10,6 +10,7 @@ Their structure depends on whether it's animated or not:
 |-----------|------|-------|-------------|
 | `a`       | {link:values/int-boolean} | Animated | Whether the property is animated |
 | `k`       | | Value or Keyframes | When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes. |
+| `ty`      | {link:constants/property-type} | Property Type | Compact type identifier indicating the value type |
 
 <h3 id="base-keyframe">Keyframes</h3>
 

--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -276,7 +276,7 @@ Static example (a triangular path):
         "i": [[0, 0], [0, 0], [0, 0]],
         "o": [[0, 0], [0, 0], [0, 0]]
     },
-    "ty": "p"
+    "ty": "b"
 }
 ```
 
@@ -307,7 +307,7 @@ Animated example (a triangle morphing into a different shape):
             }]
         }
     ],
-    "ty": "p"
+    "ty": "b"
 }
 ```
 

--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -108,6 +108,37 @@ In the following example, the ball moves left and right, on the background you c
 
 Animatable {link:values/vector}.
 
+Static example (a scale of `[100, 100]`):
+
+```json
+{
+    "a": 0,
+    "k": [100, 100],
+    "ty": "v"
+}
+```
+
+Animated example (scale animating from `[100, 100]` to `[50, 50]`):
+
+```json
+{
+    "a": 1,
+    "k": [
+        {
+            "t": 0,
+            "s": [100, 100],
+            "o": {"x": [0.333, 0.333], "y": [0, 0]},
+            "i": {"x": [0.667, 0.667], "y": [1, 1]}
+        },
+        {
+            "t": 60,
+            "s": [50, 50]
+        }
+    ],
+    "ty": "v"
+}
+```
+
 {schema_object:properties/vector-property}
 <tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
 <tr><td>`k`</td>
@@ -131,6 +162,37 @@ Animatable scalar (single number value).
 Note that when animated it uses {link:properties/vector-keyframe:Vector Keyframes},
 so instead of scalars keyframes have arrays with a single values.
 
+Static example (an opacity of `100`):
+
+```json
+{
+    "a": 0,
+    "k": 100,
+    "ty": "s"
+}
+```
+
+Animated example (rotation from `0` to `360` degrees):
+
+```json
+{
+    "a": 1,
+    "k": [
+        {
+            "t": 0,
+            "s": [0],
+            "o": {"x": [0], "y": [0]},
+            "i": {"x": [1], "y": [1]}
+        },
+        {
+            "t": 60,
+            "s": [360]
+        }
+    ],
+    "ty": "s"
+}
+```
+
 {schema_object:properties/scalar-property}
 <tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
 <tr><td>`k`</td>
@@ -143,6 +205,39 @@ so instead of scalars keyframes have arrays with a single values.
 <h3 id="position-property">Position</h3>
 
 Animatable 2D {link:values/vector} with optional spatial tangents.
+
+Static example (a position at `[256, 256]`):
+
+```json
+{
+    "a": 0,
+    "k": [256, 256],
+    "ty": "v2"
+}
+```
+
+Animated example (position moving from `[0, 0]` to `[256, 256]` with spatial tangents):
+
+```json
+{
+    "a": 1,
+    "k": [
+        {
+            "t": 0,
+            "s": [0, 0],
+            "ti": [0, 0],
+            "to": [42.667, 42.667],
+            "o": {"x": [0.333], "y": [0]},
+            "i": {"x": [0.667], "y": [1]}
+        },
+        {
+            "t": 60,
+            "s": [256, 256]
+        }
+    ],
+    "ty": "v2"
+}
+```
 
 {schema_object:properties/position-property}
 <tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
@@ -170,6 +265,52 @@ Animatable 2D {link:values/vector} with optional spatial tangents.
 
 Animatable {link:values/bezier}.
 
+Static example (a triangular path):
+
+```json
+{
+    "a": 0,
+    "k": {
+        "c": true,
+        "v": [[256, 0], [512, 512], [0, 512]],
+        "i": [[0, 0], [0, 0], [0, 0]],
+        "o": [[0, 0], [0, 0], [0, 0]]
+    },
+    "ty": "p"
+}
+```
+
+Animated example (a triangle morphing into a different shape):
+
+```json
+{
+    "a": 1,
+    "k": [
+        {
+            "t": 0,
+            "s": [{
+                "c": true,
+                "v": [[256, 0], [512, 512], [0, 512]],
+                "i": [[0, 0], [0, 0], [0, 0]],
+                "o": [[0, 0], [0, 0], [0, 0]]
+            }],
+            "o": {"x": [0.333], "y": [0]},
+            "i": {"x": [0.667], "y": [1]}
+        },
+        {
+            "t": 60,
+            "s": [{
+                "c": true,
+                "v": [[256, 0], [512, 256], [0, 256]],
+                "i": [[0, 0], [0, 0], [0, 0]],
+                "o": [[0, 0], [0, 0], [0, 0]]
+            }]
+        }
+    ],
+    "ty": "p"
+}
+```
+
 {schema_object:properties/bezier-property}
 <tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
 <tr><td>`k`</td>
@@ -188,6 +329,37 @@ Animatable {link:values/bezier}.
 <h3 id="color-property">Color</h3>
 
 Animatable {link:values/color}.
+
+Static example (red):
+
+```json
+{
+    "a": 0,
+    "k": [1, 0, 0],
+    "ty": "c"
+}
+```
+
+Animated example (color transitioning from red to blue):
+
+```json
+{
+    "a": 1,
+    "k": [
+        {
+            "t": 0,
+            "s": [1, 0, 0],
+            "o": {"x": [0.333], "y": [0]},
+            "i": {"x": [0.667], "y": [1]}
+        },
+        {
+            "t": 60,
+            "s": [0, 0, 1]
+        }
+    ],
+    "ty": "c"
+}
+```
 
 {schema_object:properties/color-property}
 <tr><td>`a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>
@@ -208,6 +380,43 @@ Animatable {link:values/color}.
 <h3 id="gradient-property">Gradient</h3>
 
 Animatable {link:values/gradient}.
+
+Static example (a gradient with 3 color stops):
+
+```json
+{
+    "p": 3,
+    "k": {
+        "a": 0,
+        "k": [0, 1, 0, 0, 0.5, 0, 1, 0, 1, 0, 0, 1]
+    },
+    "ty": "g"
+}
+```
+
+Animated example (gradient transitioning between two color configurations):
+
+```json
+{
+    "p": 2,
+    "k": {
+        "a": 1,
+        "k": [
+            {
+                "t": 0,
+                "s": [0, 1, 0, 0, 1, 0, 0, 1],
+                "o": {"x": [0.333], "y": [0]},
+                "i": {"x": [0.667], "y": [1]}
+            },
+            {
+                "t": 60,
+                "s": [0, 0, 1, 0, 1, 1, 1, 0]
+            }
+        ]
+    },
+    "ty": "g"
+}
+```
 
 {schema_object:properties/gradient-property}
 <tr><td>`k.a`</td><td>{link:values/int-boolean}</td><td>Animated</td><td>Whether the property is animated</td></tr>

--- a/docs/specs/properties.md
+++ b/docs/specs/properties.md
@@ -10,7 +10,20 @@ Their structure depends on whether it's animated or not:
 |-----------|------|-------|-------------|
 | `a`       | {link:values/int-boolean} | Animated | Whether the property is animated |
 | `k`       | | Value or Keyframes | When it's not animated, `k` will contain the value directly. When animated, `k` will be an array of keyframes. |
-| `ty`      | {link:constants/property-type} | Property Type | Compact type identifier indicating the value type |
+| `ty`      | {link:constants/property-type} | Property Type | Optional type identifier, allowing parsers to determine the value type without full schema awareness |
+
+In most cases, the property type can be determined by looking at the parent object.
+For example, a Transform's `r` attribute is always a Scalar Property and its `s` attribute is always a Vector Property.
+
+However, having an explicit `ty` is useful in cases where the property is processed
+without its parent context. For example:
+
+* **Slots**: when resolving slot values, the parser receives a property without
+  knowing which parent object it belongs to. The `ty` field allows the parser to
+  correctly interpret and validate the property value without traversing the
+  full object hierarchy.
+* **Validation**: tools can verify that a property's `ty` matches its expected
+  type, catching mismatches early without requiring full schema traversal.
 
 <h3 id="base-keyframe">Keyframes</h3>
 

--- a/schema/constants/property-type.json
+++ b/schema/constants/property-type.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "title": "Property Type",
+    "description": "Compact data type identifier for animatable properties.",
+    "oneOf": [
+        {
+            "title": "Scalar",
+            "description": "Single numeric value (e.g., opacity, rotation angle).",
+            "const": "s"
+        },
+        {
+            "title": "Vector",
+            "description": "Array of numbers with variable length.",
+            "const": "v"
+        },
+        {
+            "title": "Position",
+            "description": "2D vector representing a position in space.",
+            "const": "v2"
+        },
+        {
+            "title": "Color",
+            "description": "RGB or RGBA color value.",
+            "const": "c"
+        },
+        {
+            "title": "Bezier",
+            "description": "Cubic bezier path shape.",
+            "const": "p"
+        },
+        {
+            "title": "Gradient",
+            "description": "Gradient color stops.",
+            "const": "g"
+        }
+    ]
+}

--- a/schema/constants/property-type.json
+++ b/schema/constants/property-type.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "string",
     "title": "Property Type",
-    "description": "Compact data type identifier for animatable properties.",
+    "description": "Optional type identifier for animatable properties, allowing parsers to determine the value type without full schema awareness.",
     "oneOf": [
         {
             "title": "Scalar",

--- a/schema/constants/property-type.json
+++ b/schema/constants/property-type.json
@@ -27,7 +27,7 @@
         {
             "title": "Bezier",
             "description": "Cubic bezier path shape.",
-            "const": "p"
+            "const": "b"
         },
         {
             "title": "Gradient",

--- a/schema/properties/bezier-property.json
+++ b/schema/properties/bezier-property.json
@@ -1,48 +1,56 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "title": "Bezier Property",
-    "description": "An animatable property that holds a Bezier shape",
-    "allOf": [
-        {
-            "$ref": "#/$defs/helpers/slottable-property"
-        }
-    ],
-    "oneOf": [
-        {
-            "$comment": "Not animated",
-            "properties": {
-                "a": {
-                    "title": "Animated",
-                    "description": "Whether the property is animated",
-                    "$ref": "#/$defs/values/int-boolean",
-                    "const": 0
-                },
-                "k": {
-                    "title": "Value",
-                    "description": "Static Value",
-                    "$ref": "#/$defs/values/bezier"
-                }
-            }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "Bezier Property",
+  "description": "An animatable property that holds a Bezier shape",
+  "allOf": [
+    {
+      "$ref": "#/$defs/helpers/slottable-property"
+    }
+  ],
+  "properties": {
+    "ty": {
+      "title": "Property Type",
+      "description": "Property type, must be 'p' for Bezier Property",
+      "$ref": "#/$defs/constants/property-type",
+      "const": "p"
+    }
+  },
+  "oneOf": [
+    {
+      "$comment": "Not animated",
+      "properties": {
+        "a": {
+          "title": "Animated",
+          "description": "Whether the property is animated",
+          "$ref": "#/$defs/values/int-boolean",
+          "const": 0
         },
-        {
-            "$comment": "Animated",
-            "properties": {
-                "a": {
-                    "title": "Animated",
-                    "description": "Whether the property is animated",
-                    "$ref": "#/$defs/values/int-boolean",
-                    "const": 1
-                },
-                "k": {
-                    "type": "array",
-                    "title": "Keyframes",
-                    "description": "Array of keyframes",
-                    "items": {
-                            "$ref": "#/$defs/properties/bezier-keyframe"
-                    }
-                }
-            }
+        "k": {
+          "title": "Value",
+          "description": "Static Value",
+          "$ref": "#/$defs/values/bezier"
         }
-    ]
+      }
+    },
+    {
+      "$comment": "Animated",
+      "properties": {
+        "a": {
+          "title": "Animated",
+          "description": "Whether the property is animated",
+          "$ref": "#/$defs/values/int-boolean",
+          "const": 1
+        },
+        "k": {
+          "type": "array",
+          "title": "Keyframes",
+          "description": "Array of keyframes",
+          "items": {
+            "$ref": "#/$defs/properties/bezier-keyframe"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/schema/properties/bezier-property.json
+++ b/schema/properties/bezier-property.json
@@ -11,9 +11,9 @@
   "properties": {
     "ty": {
       "title": "Property Type",
-      "description": "Property type, must be 'p' for Bezier Property when present",
+      "description": "Property type, must be 'b' for Bezier Property when present",
       "$ref": "#/$defs/constants/property-type",
-      "const": "p"
+      "const": "b"
     }
   },
   "oneOf": [

--- a/schema/properties/bezier-property.json
+++ b/schema/properties/bezier-property.json
@@ -11,7 +11,7 @@
   "properties": {
     "ty": {
       "title": "Property Type",
-      "description": "Property type, must be 'p' for Bezier Property",
+      "description": "Property type, must be 'p' for Bezier Property when present",
       "$ref": "#/$defs/constants/property-type",
       "const": "p"
     }

--- a/schema/properties/color-property.json
+++ b/schema/properties/color-property.json
@@ -8,6 +8,14 @@
             "$ref": "#/$defs/helpers/slottable-property"
         }
     ],
+    "properties": {
+        "ty": {
+            "title": "Property Type",
+            "description": "Property type, must be 'c' for Color Property",
+            "$ref": "#/$defs/constants/property-type",
+            "const": "c"
+        }
+    },
     "oneOf": [
         {
             "$comment": "Not animated",

--- a/schema/properties/color-property.json
+++ b/schema/properties/color-property.json
@@ -11,7 +11,7 @@
     "properties": {
         "ty": {
             "title": "Property Type",
-            "description": "Property type, must be 'c' for Color Property",
+            "description": "Property type, must be 'c' for Color Property when present",
             "$ref": "#/$defs/constants/property-type",
             "const": "c"
         }

--- a/schema/properties/gradient-property.json
+++ b/schema/properties/gradient-property.json
@@ -6,7 +6,7 @@
     "properties": {
         "ty": {
             "title": "Property Type",
-            "description": "Property type, must be 'g' for Gradient Property",
+            "description": "Property type, must be 'g' for Gradient Property when present",
             "$ref": "#/$defs/constants/property-type",
             "const": "g"
         },

--- a/schema/properties/gradient-property.json
+++ b/schema/properties/gradient-property.json
@@ -4,6 +4,12 @@
     "title": "Gradient Property",
     "description": "An animatable property that holds a Gradient",
     "properties": {
+        "ty": {
+            "title": "Property Type",
+            "description": "Property type, must be 'g' for Gradient Property",
+            "$ref": "#/$defs/constants/property-type",
+            "const": "g"
+        },
         "p": {
             "title": "Color stop count",
             "type": "number"

--- a/schema/properties/position-property.json
+++ b/schema/properties/position-property.json
@@ -11,7 +11,7 @@
     "properties": {
         "ty": {
             "title": "Property Type",
-            "description": "Property type, must be 'v2' for Position Property",
+            "description": "Property type, must be 'v2' for Position Property when present",
             "$ref": "#/$defs/constants/property-type",
             "const": "v2"
         }

--- a/schema/properties/position-property.json
+++ b/schema/properties/position-property.json
@@ -8,6 +8,14 @@
             "$ref": "#/$defs/helpers/slottable-property"
         }
     ],
+    "properties": {
+        "ty": {
+            "title": "Property Type",
+            "description": "Property type, must be 'v2' for Position Property",
+            "$ref": "#/$defs/constants/property-type",
+            "const": "v2"
+        }
+    },
     "oneOf": [
         {
             "$comment": "Not animated",

--- a/schema/properties/scalar-property.json
+++ b/schema/properties/scalar-property.json
@@ -8,6 +8,14 @@
             "$ref": "#/$defs/helpers/slottable-property"
         }
     ],
+    "properties": {
+        "ty": {
+            "title": "Property Type",
+            "description": "Property type, must be 's' for Scalar Property",
+            "$ref": "#/$defs/constants/property-type",
+            "const": "s"
+        }
+    },
     "oneOf": [
         {
             "$comment": "Not animated",

--- a/schema/properties/scalar-property.json
+++ b/schema/properties/scalar-property.json
@@ -11,7 +11,7 @@
     "properties": {
         "ty": {
             "title": "Property Type",
-            "description": "Property type, must be 's' for Scalar Property",
+            "description": "Property type, must be 's' for Scalar Property when present",
             "$ref": "#/$defs/constants/property-type",
             "const": "s"
         }

--- a/schema/properties/vector-property.json
+++ b/schema/properties/vector-property.json
@@ -11,7 +11,7 @@
     "properties": {
         "ty": {
             "title": "Property Type",
-            "description": "Property type, must be 'v' for Vector Property",
+            "description": "Property type, must be 'v' for Vector Property when present",
             "$ref": "#/$defs/constants/property-type",
             "const": "v"
         }

--- a/schema/properties/vector-property.json
+++ b/schema/properties/vector-property.json
@@ -8,6 +8,14 @@
             "$ref": "#/$defs/helpers/slottable-property"
         }
     ],
+    "properties": {
+        "ty": {
+            "title": "Property Type",
+            "description": "Property type, must be 'v' for Vector Property",
+            "$ref": "#/$defs/constants/property-type",
+            "const": "v"
+        }
+    },
     "oneOf": [
         {
             "$comment": "Not animated",


### PR DESCRIPTION
based on https://github.com/lottie/lottie-spec/discussions/22

## Summary

Introduces an optional "ty" field to animatable properties that provides a compact type identifier indicating the value type. This allows implementations to determine the property type without relying solely on context.

 Changes:
  - Added new property-type constant enum definition
  - Added ty property to all property schemas (scalar, vector, position, color, bezier,
  gradient)
  - Updated documentation for properties and constants

TODO:
- [x] add examples to cover all scenarios 
- ~(add modfiers )~ we will add in a differnet PR