### PR TITLE
Add branching and contribution workflow to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,33 @@ Specification License version that you agree to be bound by.
 
 Here is an [example of what that pull request should look like](https://github.com/lottie/lottie-spec/pull/9).
 
+
+## Branching and Contribution Workflow
+
+This repository uses a two-branch workflow to protect `main` from unstable or incomplete work:
+
+- **`dev`** — The integration branch. All pull requests must target `dev`.
+- **`main`** — The release branch. Only updated by merging `dev` into `main` when preparing a release.
+
+### Contributing
+
+1. Create a feature branch from `dev`.
+2. Open a pull request targeting `dev`.
+3. PRs are squash-merged into `dev` to keep the history clean.
+
+### Releasing
+
+When `dev` is stable and ready for release:
+
+1. Merge `dev` into `main` using a **merge commit** to preserve a clear release boundary.
+2. Update the schema `$id` in `root.json`.
+3. Create and push a git tag (e.g., `1.0`).
+4. Await GitHub Actions completion.
+5. Trigger the tag-latest workflow if applicable.
+
+See the [Building and Deploying](https://github.com/lottie/lottie-spec/wiki/Building-and-Deploying) wiki page for full details on versioning and deployment.
+
+### Branch Protection
+
+`main` is protected — direct pushes and PRs to `main` are not allowed. All changes flow through `dev` first.
+


### PR DESCRIPTION
Previously (e.g. https://github.com/lottie/lottie-spec/pull/110), we created an additional branch, such as `lottie:1-0-fixes`, to merge changes before a new release. Introduces a `dev` branch as the integration branch to protect `main` from unstable or incomplete work and to avoid confusion about where to merge new changes. 

All PRs must now target `dev`. When `dev` is stable, it gets merged into
`main` with a merge commit to create a clear release boundary.

The README now documents:
- Two-branch workflow (`dev` → `main`)
- Contribution steps (feature branches from `dev`, squash-merge PRs)
- Release process (aligned with the existing Building and Deploying wiki)
- Branch protection policy for `main`

If all is good, we can update we should:
1. update https://github.com/lottie/lottie-spec/wiki/Building-and-Deploying 
2. Adjust https://github.com/lottie/lottie-spec/pull/143
3. Point existing PRs to the `dev` branch